### PR TITLE
More cleanup regarding headers, declarations, etc.

### DIFF
--- a/pwauth/auth_aix.c
+++ b/pwauth/auth_aix.c
@@ -47,7 +47,7 @@
  * status code. (This version for systems with a getuserpw() call.)
  */
 
-int check_auth(char *login, char *passwd)
+int check_auth(const char *login, const char *passwd)
 {
     char *cpass;
     struct userpw *upwd= getuserpw(login);
@@ -85,7 +85,7 @@ int check_auth(char *login, char *passwd)
  * interface and return a status code.
  */
 
-int check_auth(char *login, char *passwd)
+int check_auth(const char *login, const char *passwd)
 {
     char *cpass;
     char *message;

--- a/pwauth/auth_bsd.c
+++ b/pwauth/auth_bsd.c
@@ -49,7 +49,7 @@
  * (This version for systems with only a getpwnam() call.)
  */
 
-int check_auth(char *login, char *passwd)
+int check_auth(const char *login, const char *passwd)
 {
     char *cpass;
     struct passwd *pwd= getpwnam(login);

--- a/pwauth/auth_hpux.c
+++ b/pwauth/auth_hpux.c
@@ -45,7 +45,7 @@
  * (This version for systems with a getprpwnam() call.)
  */
 
-int check_auth(char *login, char *passwd)
+int check_auth(const char *login, const char *passwd)
 {
     char *cpass;
     struct pr_passwd *pwd= getprpwnam(login);

--- a/pwauth/auth_mdw.c
+++ b/pwauth/auth_mdw.c
@@ -38,8 +38,8 @@
 #include <pwd.h>
 #endif
 #include <shadow.h>	  /* is -I/usr/local/include on gcc command? */
-char *kg_pwhash(char *clear, char *user, char *result, int resultlen);
-char *pw_encrypt();
+char *kg_pwhash(const char *clear, const char *user, char *result, int resultlen);
+char *pw_encrypt(const char *clear, const char *salt);
 #endif /* SHADOW_MDW */
 
 #ifdef SHADOW_MDW
@@ -50,7 +50,7 @@ char *pw_encrypt();
  * (This version for systems with kg_pwhash() call.)
  */
 
-int check_auth(char *login, char *passwd)
+int check_auth(const char *login, const char *passwd)
 {
     char *cpass;
     char bf[40];

--- a/pwauth/auth_openbsd.c
+++ b/pwauth/auth_openbsd.c
@@ -45,7 +45,7 @@
  * (This version for systems with auth_usercheck() call.)
  */
 
-int check_auth(char *login, char *passwd)
+int check_auth(const char *login, const char *passwd)
 {
     auth_session_t *as;
     login_cap_t *lc;

--- a/pwauth/auth_pam.c
+++ b/pwauth/auth_pam.c
@@ -56,8 +56,8 @@
 /* Application data structure passed to PAM_conv: */
 
 struct ad_user {
-	char *login;
-	char *passwd;
+	const char *login;
+	const char *passwd;
 	};
 
 /* The pam_unix.so library in Solaris 2.6 fails to pass along appdata_ptr
@@ -150,7 +150,7 @@ int PAM_conv (int num_msg, const struct pam_message **msg,
  * (This version for systems using PAM.)
  */
 
-int check_auth(char *login, char *passwd)
+int check_auth(const char *login, const char *passwd)
 {
 #ifndef PAM_SOLARIS_26
     struct ad_user user_info= {login, passwd};

--- a/pwauth/auth_sun.c
+++ b/pwauth/auth_sun.c
@@ -38,8 +38,8 @@
 #include <pwd.h>
 #endif
 #include <shadow.h>
-struct spwd *getspnam();
-char *crypt();
+struct spwd *getspnam(const char *name);
+char *crypt(const char *key, const char *salt);
 #endif /* SHADOW_SUN */
 
 #ifdef SHADOW_JFH
@@ -47,8 +47,8 @@ char *crypt();
 #include <pwd.h>
 #endif
 #include <shadow.h>	  /* this may be hidden in /usr/local/include */
-struct spwd *getspnam();
-char *pw_encrypt();
+struct spwd *getspnam(const char *name);
+char *pw_encrypt(const char *clear, const char *salt);
 #endif /* SHADOW_JFH */
 
 #if defined(SHADOW_JFH) || defined(SHADOW_SUN)
@@ -59,7 +59,7 @@ char *pw_encrypt();
  * (This version for systems with getspnam() call.)
  */
 
-int check_auth(char *login, char *passwd)
+int check_auth(const char *login, const char *passwd)
 {
     char *cpass;
     struct spwd *spwd= getspnam(login);

--- a/pwauth/checkfaillog.c
+++ b/pwauth/checkfaillog.c
@@ -44,7 +44,8 @@ int main(int argc, char **argv)
 {
     int i, j;
     int reset= 0, verbose= 1;
-    char *user= NULL, *msg= NULL;
+    char *user= NULL;
+    const char *msg= NULL;
     uid_t uid= getuid();
 
     /* Parse command line */

--- a/pwauth/fail_check.c
+++ b/pwauth/fail_check.c
@@ -36,6 +36,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <utmp.h>
+#include <time.h>
 
 #include "config.h"
 #include "fail_log.h"
@@ -52,7 +53,7 @@
  *      <count> failures since last login.  Last was <time> on <tty>.\n
  */
 
-char *check_fails(uid_t uid, int reset, int verbose)
+const char *check_fails(uid_t uid, int reset, int verbose)
 {
     struct faillog flog;
     int flfd;
@@ -90,12 +91,12 @@ char *check_fails(uid_t uid, int reset, int verbose)
 	    ct[19]= '\0';
 	if (now - flog.fail_time < (24*3600))
 	    ct+= 11;
-	sprintf(buf,"%d %s since last login.  Last was %s on %s.",
+	snprintf(buf, sizeof(buf), "%d %s since last login.  Last was %s on %s.",
 	    flog.fail_cnt, flog.fail_cnt == 1 ? "failure" : "failures",
 	    ct, flog.fail_line);
     }
     else
-	sprintf(buf,"%d:%ld::%s",
+	snprintf(buf, sizeof(buf), "%d:%ld::%s",
 	    flog.fail_cnt, flog.fail_time, flog.fail_line);
 
     /* Reset the count, if that was desired */
@@ -120,7 +121,7 @@ char *check_fails(uid_t uid, int reset, int verbose)
  *   <count> failures since last login.  Last was <time> from <host> on <tty>.\n
  */
 
-char *check_fails(uid_t uid, int reset, int verbose)
+const char *check_fails(uid_t uid, int reset, int verbose)
 {
     struct badlogin flog;
     int flfd;
@@ -159,16 +160,16 @@ char *check_fails(uid_t uid, int reset, int verbose)
 	if (now - flog.bl_time < (24*3600))
 	    ct+= 11;
 	if (flog.bl_host[0] != '\0')
-	    sprintf(buf,"%d %s since last login.  Last was %s from %s on %s.",
+	    snprintf(buf, sizeof(buf), "%d %s since last login.  Last was %s from %s on %s.",
 		flog.count, flog.count == 1 ? "failure" : "failures",
 		ct, flog.bl_host, flog.bl_line);
 	else
-	    sprintf(buf,"%d %s since last login.  Last was %s on %s.",
+	    snprintf(buf, sizeof(buf), "%d %s since last login.  Last was %s on %s.",
 		flog.count, flog.count == 1 ? "failure" : "failures",
 		ct, flog.bl_line);
     }
     else
-	sprintf(buf,"%d:%ld:%s:%s",
+	snprintf(buf, sizeof(buf), "%d:%ld:%s:%s",
 	    flog.count, flog.bl_time, flog.bl_host, flog.bl_line);
 
     /* Reset the count, if that was desired */

--- a/pwauth/fail_log.c
+++ b/pwauth/fail_log.c
@@ -47,7 +47,7 @@
  * uses this anymore, so I'm not going to bother implementing that.
  */
 
-int check_fails()
+int check_fails(void)
 {
     int result= 1;
     struct faillog flog;
@@ -70,7 +70,7 @@ int check_fails()
 /* LOG_FAILURE - Do whatever we need to do to log a failed login attempt.
  */
 
-void log_failure()
+void log_failure(void)
 {
     int flfd;
     struct faillog flog;
@@ -112,7 +112,7 @@ void log_failure()
  * been exceeded, then the count is reset to zero.
  */
 
-int check_fails()
+int check_fails(void)
 {
     int result= 1;
 #if defined(MAX_FAIL_COUNT) || defined(RESET_FAIL_COUNT)
@@ -149,7 +149,7 @@ int check_fails()
 /* LOG_FAILURE - Do whatever we need to do to log a failed login attempt.
  */
 
-log_failure()
+int log_failure(void)
 {
     int flfd;
     struct badlogin flog;

--- a/pwauth/lastlog.c
+++ b/pwauth/lastlog.c
@@ -31,14 +31,14 @@
  * =======================================================================
  */
 
-#include <time.h>
+#include <unistd.h>
 
 #include "pwauth.h"
 
 /* LASTLOG - update the system's lastlog */
 
 #ifdef UNIX_LASTLOG
-void lastlog()
+void lastlog(void)
 {
     struct lastlog ll;
     int fd;
@@ -57,7 +57,7 @@ void lastlog()
 
     if ((fd= open(LASTLOG,O_WRONLY)) < 0) return;
 
-    lseek(fd, (long)(hisuid * sizeof(struct lastlog)), 0);
+    lseek(fd, (long)(hisuid * sizeof(struct lastlog)), SEEK_SET);
     write(fd, &ll, sizeof(struct lastlog));
     close(fd);
 }

--- a/pwauth/main.c
+++ b/pwauth/main.c
@@ -44,8 +44,7 @@ int server_uids[]= {SERVER_UIDS, 0};
 #endif
 
 
-int
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
 #ifdef ENV_METHOD
     char *login, *passwd;
@@ -55,8 +54,8 @@ main(int argc, char **argv)
 #endif
 #ifdef SERVER_UIDS
     int uid;
-#endif
     int i;
+#endif
     int status;
     struct rlimit rlim;
 

--- a/pwauth/nologin.c
+++ b/pwauth/nologin.c
@@ -38,7 +38,7 @@
  * uid is below MIN_NOLOGIN_UID.
  */
 
-check_nologin()
+int check_nologin(void)
 {
     /* Return true if the file does not exist (the access() function returns
      * true if the file doesn't exist - pretty dumb, eh?) */

--- a/pwauth/pwauth.h
+++ b/pwauth/pwauth.h
@@ -37,6 +37,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -130,4 +131,5 @@ extern int haveuid;
 
 void snooze(int seconds);
 void lastlog(void);
-int check_auth(char *login, char *passwd);
+int check_auth(const char *login, const char *passwd);
+int check_nologin(void);

--- a/pwauth/snooze.c
+++ b/pwauth/snooze.c
@@ -42,8 +42,7 @@
  * sleep time, if other pwauth processes are in sleeps.
  */
 
-void
-snooze(int seconds)
+void snooze(int seconds)
 {
     int slfd;
     struct flock lock;


### PR DESCRIPTION
Use ANSI prototypes for functions.  Make sure <time.h> is included
everywhere time() gets called. Don't use unsafe sprintf() but
snprintf() instead.  Use const char * strings where appropriate
(i.e. where arguments don't get modified as side-effects).

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>